### PR TITLE
Potential fix for code scanning alert no. 15: Exception text reinterpreted as HTML

### DIFF
--- a/server/src/pogo-accounts.routes.ts
+++ b/server/src/pogo-accounts.routes.ts
@@ -14,7 +14,7 @@ pogoAccountsRouter.get("/", async (_req, res) => {
         const pogoAccounts = await collections.pogoAccounts.find({}).toArray()
         res.status(200).send(pogoAccounts)
     } catch (error) {
-        res.status(500).send(error.message)
+        res.status(500).send(escape(error.message))
     }
 })
 
@@ -38,7 +38,7 @@ pogoAccountsRouter.get("/:id", async (req, res) => {
         }
 
     } catch (error) {
-        res.status(500).send(`Failed to find a pogo account with id: ${req?.params?.id}`)
+        res.status(500).send(`Failed to find a pogo account with id: ${escape(req?.params?.id)}`)
     }
 
 })
@@ -63,7 +63,7 @@ pogoAccountsRouter.post("/", async (req, res) => {
         }
 
     } catch (error) {
-        res.status(500).send(error.message)
+        res.status(500).send(escape(error.message))
     }
 })
 
@@ -116,7 +116,7 @@ pogoAccountsRouter.delete("/:id", async (req, res) => {
         }
 
     } catch (error) {
-        res.status(500).send(error.message)
+        res.status(500).send(escape(error.message))
     }
 })
 


### PR DESCRIPTION
Potential fix for [https://github.com/indervirsingh/pogo-accounts/security/code-scanning/15](https://github.com/indervirsingh/pogo-accounts/security/code-scanning/15)

To fix the problem, we need to ensure that any error messages sent in the response are properly escaped to prevent XSS attacks. We can use the `escape-html` library, which is already imported in the file, to escape the error messages before sending them in the response.

- Identify all instances where error messages are sent in the response.
- Use the `escape` function from the `escape-html` library to escape the error messages before sending them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error notifications for account operations by safely formatting error messages, ensuring that any displayed information is secure and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->