### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "mongodb": "^6.14.2",
-    "escape-html": "^1.0.3"
+    "escape-html": "^1.0.3",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/pogo-accounts.routes.ts
+++ b/server/src/pogo-accounts.routes.ts
@@ -2,9 +2,17 @@ import * as express from "express"
 import * as mongodb from "mongodb"
 import { collections } from "./database"
 import * as escape from "escape-html"
+import * as rateLimit from "express-rate-limit";
 
 export const pogoAccountsRouter = express.Router()
 pogoAccountsRouter.use(express.json())
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+pogoAccountsRouter.use(limiter);
 
 // The route is "/" because all the endpoints from this file are registered under 'pogo-accounts' route
 pogoAccountsRouter.get("/", async (_req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/indervirsingh/pogo-accounts/security/code-scanning/2](https://github.com/indervirsingh/pogo-accounts/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application. This can be achieved by using the `express-rate-limit` middleware. We will set up a rate limiter that restricts the number of requests a client can make within a specified time window. This will help prevent abuse and mitigate the risk of DoS attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per time window).
4. Apply the rate limiter to the routes that perform database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented request rate limiting on key endpoints to enhance system stability and prevent excessive usage, ensuring a smoother experience under high-demand conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->