### PR TITLE
Potential fix for code scanning alert no. 16: Exception text reinterpreted as HTML

### DIFF
--- a/server/src/pogo-accounts.routes.ts
+++ b/server/src/pogo-accounts.routes.ts
@@ -114,7 +114,7 @@ pogoAccountsRouter.put("/:id", async (req, res) => {
         }
 
     } catch (error) {
-        res.status(400).send(error.message)
+        res.status(400).send(escape(error.message))
     }
 })
 


### PR DESCRIPTION
Potential fix for [https://github.com/indervirsingh/pogo-accounts/security/code-scanning/16](https://github.com/indervirsingh/pogo-accounts/security/code-scanning/16)

To fix the problem, we need to ensure that any error messages sent back in the response are properly escaped to prevent XSS vulnerabilities. This can be done using the `escape-html` library, which is already imported in the file. We will wrap the `error.message` in the `escape` function before sending it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
